### PR TITLE
Renamed COVID abbreviation to avoid confusion with No Prize abbreviation

### DIFF
--- a/2022.html
+++ b/2022.html
@@ -133,7 +133,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/achievement-winners.html
+++ b/achievement-winners.html
@@ -123,7 +123,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/captains.html
+++ b/captains.html
@@ -137,7 +137,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/concepts.html
+++ b/concepts.html
@@ -137,7 +137,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -96,7 +96,7 @@ td.sp:after {
 	content: "SP";
 }
 td.COVID:after {
-	content: "NP";
+	content: "CV";
 }
 td.total a {
 	cursor: pointer;

--- a/hof.html
+++ b/hof.html
@@ -125,7 +125,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
       <div class="note noNote">NO: No official judging. No prizes awarded to any band.</div>
       <div class="note npNote">NP: Failed to place. No prize awarded.</div>
       <div class="note spNote">SP: Failed to place. Awarded "Special Mention" by the city.</div>
-      <div class="note covidNote">NP: No parade due to COVID-19.</div>
+      <div class="note covidNote">CV: No parade due to COVID-19.</div>
     </div>
   </div>
 
@@ -267,7 +267,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -139,7 +139,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/mumtape.html
+++ b/mumtape.html
@@ -348,7 +348,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/random.html
+++ b/random.html
@@ -133,7 +133,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->

--- a/video.html
+++ b/video.html
@@ -286,7 +286,7 @@
       <div class="container">
         <p class="m-0 text-center text-white"><strong><a href="https://mummers.github.io/stringbands/sbdb-1.0/index.html" class="alert-link">Click here</a></strong> to return to V1 of the database.</p>
         <hr>
-        <p class="m-0 text-center text-white">A <a href="https://bhamburg.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
+        <p class="m-0 text-center text-white">A <a href="https://burgbits.com">Brian Hamburg</a> and <a href="https://tjferry.com/">TJ Ferry</a> collaboration. A special thanks to the following:</p>
         <p class="m-0 text-center text-white">Brian Maher, John Gilbert, Joe "Bagel" Strine, Russ Coleman and Joe Fink.</p>
       </div>
       <!-- /.container -->


### PR DESCRIPTION
Also updated bhamburg.com to burgbits.com